### PR TITLE
Fix fatal bug crashing game

### DIFF
--- a/http/game/play/Answer.jsx
+++ b/http/game/play/Answer.jsx
@@ -37,7 +37,6 @@ class Answer extends Component {
 		let positionY = this.state.position.y;
 		const velocityX = this.state.velocity.vx;
 		let velocityY = this.state.velocity.vy;
-		const offsetWidth = this.state.offsetWidth;
 
 		velocityY += dt * ((Math.random() - 0.5) / 10000);
 		if ((velocityY) < 0.03) velocityY = +velocityY + 0.03;

--- a/http/game/play/River.jsx
+++ b/http/game/play/River.jsx
@@ -32,7 +32,7 @@ class River extends Component {
 	componentDidMount() {
 		// River Reflections
 		this.setRiverWidth();
-		/* this.startRiverReflections();*/
+		this.startRiverReflections();
 		// Answers
 		this.updateAnswers();
 		let answerUpdate = setInterval(this.updateAnswers, 2500);
@@ -69,9 +69,11 @@ class River extends Component {
 			if (newAnswer) answersToAdd.unshift(newAnswer);
 			let randomData = this.props.answerData[Math.floor(
 				Math.random() * this.props.answerData.length)];
-			while (currentAnswers.indexOf(randomData) >= 0) {
-				randomData = this.props.answerData[Math.floor(
-					Math.random() * this.props.answerData.length)];
+			if (currentAnswers.length * 2 <= this.props.answerData.length) {
+				while (currentAnswers.indexOf(randomData) >= 0) {
+					randomData = this.props.answerData[Math.floor(
+						Math.random() * this.props.answerData.length)];
+				}
 			}
 			newAnswer = randomData;
 		}
@@ -391,14 +393,14 @@ class River extends Component {
 			<div className={'river' + this.state.flashClass} ref="river">
 				<div className="answers">
 					{answers}
-					{/* {this.state.riverReflectionGroups.map((riverReflectionGroup) =>
+					{this.state.riverReflectionGroups.map((riverReflectionGroup) =>
 						<RiverReflectionGroup
 							x={riverReflectionGroup.x}
 							y={riverReflectionGroup.y}
 							riverWidth={this.state.riverWidth}
 							key={riverReflectionGroup.key}
 						/>
-					)}*/}
+					)}
 					<Rock y={this.state.rockYPosition} present={this.props.rockPresent} ref="rock" />
 					<Canoe
 						initialImage={this.props.initialImage} ref="canoe"

--- a/http/game/play/Rock.jsx
+++ b/http/game/play/Rock.jsx
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 
+/* eslint-disable react/prefer-stateless-function */
 class Rock extends Component {
+/* eslint-enable react/prefer-stateless-function */
 	render() {
 		const rockStyle = {
 			height: '100%',

--- a/http/game/play/Rock.jsx
+++ b/http/game/play/Rock.jsx
@@ -1,22 +1,24 @@
 import React, { Component, PropTypes } from 'react';
 
-function Rock({ y, present }) {
-	const rockStyle = {
-		height: '100%',
-	};
-	let containerStyle = {
-		textAlign: 'center',
-		height: '12%',
-		margin: '0 auto',
-		transform: `translate(0px, ${y}px)`,
-		display: 'table',
-	};
-	if (!present) containerStyle.display = 'none';
-	return (
-		<div style={containerStyle}>
-			<img src="../img/obstacles/rock.svg" style={rockStyle} alt="" />
-		</div>
-	);
+class Rock extends Component {
+	render() {
+		const rockStyle = {
+			height: '100%',
+		};
+		let containerStyle = {
+			textAlign: 'center',
+			height: '12%',
+			margin: '0 auto',
+			transform: `translate(0px, ${this.props.y}px)`,
+			display: 'table',
+		};
+		if (!this.props.present) containerStyle.display = 'none';
+		return (
+			<div style={containerStyle}>
+				<img src="../img/obstacles/rock.svg" style={rockStyle} alt="" />
+			</div>
+		);
+	}
 }
 
 export default Rock;

--- a/sockets/game.js
+++ b/sockets/game.js
@@ -65,7 +65,7 @@ module.exports = (tws, m, games) => {
 	case 'answerSelected': {
 		tws.checkGameExists();
 
-		if (Math.random() < 0.05 * tws.crew().streak) {
+		if (Math.random() < 0.001 * tws.crew().streak) {
 			tws.crew().streak = 0;
 			if (Math.random() < 0) {
 				tws.addWhirlpool();


### PR DESCRIPTION
Basically what happened:

We had a while loop inside of the animation code for the answers. It would select a random answer from the pool provided until the answer selected wasn't already on the screen. Problem was - for sets with only a few questions, this would break as all the answers would already be on the screen.

Real problem - sets need to have a min. number of questions / answers. But this fixes #108.
